### PR TITLE
pass ref to Select component

### DIFF
--- a/src/WindowedSelect.js
+++ b/src/WindowedSelect.js
@@ -7,11 +7,13 @@ class WindowedSelect extends React.Component {
     const {
       options,
       windowThreshold,
+      selectRef
     } = this.props;
 
     const isWindowed = options.length >= windowThreshold;
     return (
       <Select {...this.props}
+        ref={selectRef}
         components={{
           ...this.props.components,
           ...(
@@ -28,6 +30,7 @@ class WindowedSelect extends React.Component {
 WindowedSelect.defaultProps = {
   windowThreshold: 100,
   options: [],
+  selectRef: null,
 };
 
 export default WindowedSelect;


### PR DESCRIPTION
Great wrapper, thanks.
I have an application in which I need to grab the ref to the Select component.
I tried to implement this with `React.forwardRef` but for some reason couldn't get it to work...
the one thing I wasn't certain about here was the defaultProps for `selectRef`, you might want to change that...