### PR TITLE
align license in package.json with LICENSE file

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-window": "1.8.5"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "peerDependencies": {
     "react": "^16.8.0",
     "react-dom": "^16.8.0"


### PR DESCRIPTION
This change will set the "license" property in the package.json to "MIT". 

Rationale:
The package.json's license property is currently "ISC", and was changed to that from "MIT" in [this commit](https://github.com/jacobworrel/react-windowed-select/commit/2d1cde17dde04bb29d576d20529fda61d9120df6) so this may be intentional in which case this PR should be rejected.

However, the LICENSE file, and [github](https://github.com/jacobworrel/react-windowed-select), and [npm](https://www.npmjs.com/package/react-window-select) all seem to indicate that this module is under the MIT license. If that is the intent, then this should be reflected in the package.json license property as well (or at least, the LICENSE file and the license property should not be in conflict).