### PR TITLE
fix: adds react-select and react-window to externals during build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,8 @@ module.exports = {
   },
   externals: {
     react: 'commonjs react',
-    'react-dom': 'commonjs react-dom'
+    'react-dom': 'commonjs react-dom',
+    'react-select': 'commonjs react-select',
+    'react-window': 'commonjs react-window',
   },
 };


### PR DESCRIPTION
Fixes #74 

As mentioned, the problem occurred in `@emotion/utils code`, that's used by `react-select`. The main problem is that you include both `react-select` and `react-window` in the final bundle, that is not recommended for library authors. That's why bundled emotion code works unexpectedly on server - it loses cache context.

So, this PR adds both `react-select` and `react-window` to externals that fixes problem with Next.js (and other Node environments)