### PR TITLE
Add module definition to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.1.0",
   "description": "",
   "main": "dist/main.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
Vite.js and rollup gets confused with default exports and re-exporting `* from react` when using the commonjs build. Exposing index.js as module solves the problem.

fixes https://github.com/jacobworrel/react-windowed-select/issues/114