### PR TITLE
move types to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "5.1.1",
       "license": "MIT",
       "dependencies": {
-        "@types/react": "^18.0.14",
-        "@types/react-dom": "^18.0.5",
-        "@types/react-window": "^1.8.2",
         "react-select": "^5.2.2",
         "react-window": "^1.8.6"
       },
@@ -26,6 +23,9 @@
         "@storybook/addons": "^6.1.21",
         "@storybook/react": "^6.1.21",
         "@testing-library/react": "^10.4.9",
+        "@types/react": "^18.0.14",
+        "@types/react-dom": "^18.0.5",
+        "@types/react-window": "^1.8.2",
         "babel-jest": "^26.6.3",
         "babel-loader": "^8.2.2",
         "concurrently": "^5.3.0",
@@ -8048,6 +8048,7 @@
       "version": "18.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.5.tgz",
       "integrity": "sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -8073,6 +8074,7 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.2.tgz",
       "integrity": "sha512-gP1xam68Wc4ZTAee++zx6pTdDAH08rAkQrWm4B4F/y6hhmlT9Mgx2q8lTCXnrPHXsr15XjRN9+K2DLKcz44qEQ==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -38147,6 +38149,7 @@
       "version": "18.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.5.tgz",
       "integrity": "sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -38172,6 +38175,7 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.2.tgz",
       "integrity": "sha512-gP1xam68Wc4ZTAee++zx6pTdDAH08rAkQrWm4B4F/y6hhmlT9Mgx2q8lTCXnrPHXsr15XjRN9+K2DLKcz44qEQ==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
     "check": "npm-check -u -E"
   },
   "dependencies": {
-    "@types/react": "^18.0.14",
-    "@types/react-dom": "^18.0.5",
-    "@types/react-window": "^1.8.2",
     "react-select": "^5.2.2",
     "react-window": "^1.8.6"
   },
@@ -35,6 +32,9 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
+    "@types/react": "^18.0.14",
+    "@types/react-dom": "^18.0.5",
+    "@types/react-window": "^1.8.2",
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-react": "^7.12.10",


### PR DESCRIPTION
this will allow downstream projects to continue using react-windowed-select if they haven't adopted react 18 yet