### PR TITLE
Point the package to the correct entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.1.1",
   "description": "",
   "main": "dist/main.js",
-  "module": "dist/index.js",
+  "module": "dist/main.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
`index.js` does not exist in the dist folder. The entry point is called main.js

Fixes #127 

This is only a temporary fix, because the main.js is a CJS module, not an ESM. The proper solution is to build to ESM as well as to CJS