### PR TITLE
feat: support grouped options with CreatableSelect (fixes flattenGroupedChildren)

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -10,23 +10,17 @@ export function calcOptionsLength (options) {
     : options.length;
 }
 
-export function flattenGroupedChildren (children) {
+export function flattenGroupedChildren(children) {
   return children.reduce((result, child) => {
-    const {
-      props: {
-        children: nestedChildren = [],
-      },
-    } = child;
+    if (child.props.children != null && typeof child.props.children === "string") {
+      return [...result, child];
+    } else {
+      const {
+        props: { children: nestedChildren = [] },
+      } = child;
 
-    return [
-      ...result,
-      React.cloneElement(
-        child,
-        { type: 'group' },
-        []
-      ),
-      ...nestedChildren,
-    ];
+      return [...result, React.cloneElement(child, { type: "group" }, []), ...nestedChildren];
+    }
   }, []);
 }
 

--- a/stories/CreatableSelect.stories.js
+++ b/stories/CreatableSelect.stories.js
@@ -5,7 +5,7 @@ import CreatableSelect from 'react-select/creatable';
 
 import { WindowedMenuList } from '../src';
 
-import { options200 } from './storyUtil';
+import { groupedOptions, options200 } from './storyUtil';
 
 storiesOf('Creatable Select', module)
     .add('default', () => (
@@ -26,4 +26,23 @@ storiesOf('Creatable Select', module)
                 console.groupEnd();
             }}
         />
-    ));
+    )).add('grouped', () => (
+        <CreatableSelect
+            // menuIsOpen
+            options={groupedOptions}
+            components={{ MenuList: WindowedMenuList }}
+            onChange={(newValue, actionMeta) => {
+                console.group('Value Changed');
+                console.log(newValue);
+                console.log(`action: ${actionMeta.action}`);
+                console.groupEnd();
+            }}
+            onInputChange={(inputValue, actionMeta) => {
+                console.group('Input Changed');
+                console.log(inputValue);
+                console.log(`action: ${actionMeta.action}`);
+                console.groupEnd();
+            }}
+        />
+      ))
+      


### PR DESCRIPTION
Fixes #117 

Previously, grouped options broke `MenuList` because the `flattenGroupedChildren` helper assumes that all children occur in groups.
However, with `CreatableSelect`, the "Create ..." option occurs outside of a group, as a lone `Select` option.

This PR introduces a typecheck and correct handling for this case, and also adds a working (and verifiable) `grouped` option to the Storybook story for `CreatableSelect`.